### PR TITLE
Add useragent to login response

### DIFF
--- a/rotom.proto
+++ b/rotom.proto
@@ -58,6 +58,7 @@ message MitmResponse {
         string worker_id = 1;
         AuthStatus status = 2;
         bool supports_compression = 3;
+        string useragent = 4;
     }
 
     message RpcResponse {


### PR DESCRIPTION
The useragent field (which should be the same as the one presented in welcome) can be passed to controllers through the login response
