### PR TITLE
Proposal to allow MITM capability to be given

### DIFF
--- a/rotom.proto
+++ b/rotom.proto
@@ -62,6 +62,7 @@ message MitmResponse {
         AuthStatus status = 2;
         bool supports_compression = 3;
         string useragent = 4;
+        uint64 mitm_capability = 5; // Bitwise field built up of Mitm Capability flags
     }
 
     message RpcResponse {
@@ -130,4 +131,8 @@ enum RpcStatus {
     RPC_STATUS_GOOGLE_PLAY_NOT_READY = 19;
     RPC_STATUS_LOGIN_ERROR_BAIL = 20;
     RPC_STATUS_MITM_DISALLOWED_REQUEST = 99;
+}
+
+enum MitmCapability {
+    MITM_CAPABILITY_REQUEST_LONG_SESSIONS = 1;
 }

--- a/rotom.proto
+++ b/rotom.proto
@@ -23,14 +23,14 @@ message MitmRequest {
         LoginSource source = 2;
         bytes token_proto = 3;
         string worker_id = 4;
-        bool enable_compression = 5;
+        bool enable_compression = 5;    // Controller can support compressed responses
     }
 
     message RpcRequest {
         message SingleRpcRequest {
             int32 method = 1;
             bytes payload = 2;
-            bool is_compressed = 3;
+            bool is_compressed = 3;     // This request is compressed
         }
 
         repeated SingleRpcRequest request = 1;
@@ -60,16 +60,16 @@ message MitmResponse {
     message LoginResponse {
         string worker_id = 1;
         AuthStatus status = 2;
-        bool supports_compression = 3;
+        bool supports_compression = 3;  // Agent can support compressed requests
         string useragent = 4;
-        uint64 mitm_capability = 5; // Bitwise field built up of Mitm Capability flags
+        bool request_long_sessions = 5; // Agent prefers longer sessions over fast reconnects
     }
 
     message RpcResponse {
         message SingleRpcResponse {
             int32 method = 1;
             bytes payload = 2;
-            bool is_compressed = 3;
+            bool is_compressed = 3;     // This payload response is compressed
         }
 
         RpcStatus rpc_status = 1;
@@ -131,8 +131,4 @@ enum RpcStatus {
     RPC_STATUS_GOOGLE_PLAY_NOT_READY = 19;
     RPC_STATUS_LOGIN_ERROR_BAIL = 20;
     RPC_STATUS_MITM_DISALLOWED_REQUEST = 99;
-}
-
-enum MitmCapability {
-    MITM_CAPABILITY_REQUEST_LONG_SESSIONS = 1;
 }


### PR DESCRIPTION
Introduce a capability flag which allows MITM to indicate their capability or make requests of controllers.

Implemented as an uint64 to be binary packed (assuming there may be more of these in future)
The suggested initial option is to allow disabling of fast user switching (i.e. return on jail), which is currently implemented with user agent matching.

Comments?  This could equally be done with a series of bools so a bitwise flag may be premature optimisation